### PR TITLE
Add governance policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,27 @@ This is the central home for the CDEvents community documentation.
 
 ## The CDEvents project
 
+CDEvents is a common specification for Continuous Delivery events.
+Its scope spans the entire software development lifecycle and it includes several projects:
+
+* [a specification](https://github.com/cdevents/spec)
+* various SDKs
+  * [golang](https://github.com/cdevents/go-sdk)
+  * [java](https://github.com/cdevents/go-java)
+  * [python](https://github.com/cdevents/go-python)
+* [the CDEvents website and primer](https://github.com/cdevents/cdevents.dev)
+
+Plus various experiments, proof-of-concepts and upcoming SDKs.
+
+To learn more about CDEvents:
+
+* read the [CDEvents docs and primer](https://cdevents.dev/docs/)
+* take a look at the [features we're working on](https://github.com/orgs/cdevents/projects/1)
+* take a look at the [tools integration we're working on](https://github.com/orgs/cdevents/projects/4)
+
 ## How to get involved
 
-### How to get involved
-
-[Reach out](governance.md#project-communication-channels) to see what we're up
-via:
+Reach out to see what we're up via:
 
 * [slack](https://cdeliveryfdn.slack.com/archives/C030SKZ0F4K)
 * [our mailing list](https://groups.google.com/g/cdevents-dev)
@@ -18,14 +33,19 @@ via:
   * [EMEA/APAC Friendly](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=YmV1Mmdna3RnbnYwZmszZm5nNTY2cTNuZmxfMjAyMzEwMzBUMTEwMDAwWiBsaW51eGZvdW5kYXRpb24ub3JnX21oZjBrbWdlZG42N2lobmk4cjEyOWF2cDI0QGc&tmsrc=linuxfoundation.org_mhf0kmgedn67ihni8r129avp24%40group.calendar.google.com&scp=ALL)
   * [Meeting Notes](working-group-notes.md)
 
-### Contributing
+## Contributing
 
 If you would like to contribute, see our [contributing](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)
 guidelines.
 
+See out standards and processes regarding:
+
+* [Code of conduct](https://github.com/cdevents/.github/blob/main/docs/CODE_OF_CONDUCT.md)
+* [Versioning](https://cdevents.dev/docs/primer/#versioning)
+* [Development](processes.md#contributions)
+* [Contributor Ladder](processes.md#contributor-ladder)
+
 ### Governance
 
-The project has been started by the CDF
-[SIG Events](https://github.com/cdfoundation/sig-events) and is currently
-[governed](governance.md) by a few members of the SIG.
+The project governance is documented in the [`governance.md` document](/governance.md).
 

--- a/governance.md
+++ b/governance.md
@@ -1,20 +1,20 @@
 # CDEvents Governance
 
-The CDEvents Governance committee is the governing body of the CDEvents open source project. It's an elected group that represents the contributors to the project, and has an oversight on governance and technical matters.
+The CDEvents Governing Board is the governing body of the CDEvents open source project. It's an elected group that represents the contributors to the project, and has an oversight on governance and technical matters.
 
 
-- [CDEvents Governance Committee](#CDEvents-governance-committee)
+- [CDEvents Governing Board](#CDEvents-governing-board)
 - [Governance Facilitator Role (optional)](#governance-facilitator-role-optional)
 - [Maximum Representation](#maximum-representation)
 - [Committee Responsibilities and Deliverables](#committee-responsibilities-and-deliverables)
 - [Governance Meetings and Decision-Making Process](#governance-meetings-and-decision-making-process)
 - [Elections](#elections)
 - [Permissions and access](#permissions-and-access)
-- [Governing board leave policy](#governing-board-leave-policy)
+- [Governing Board leave policy](#governing-board-leave-policy)
 
-## CDEvents Governance Committee
+## CDEvents Governing Board
 
-The CDEvents governance committee consists of five elected individuals. The five seats are held for two year terms, staggered by one year: every year either two or three of the seats are up for election.
+The CDEvents Governing Board consists of five elected individuals. The five seats are held for two year terms, staggered by one year: every year either two or three of the seats are up for election.
 
 ### Current members (Bootstrap)
 
@@ -42,13 +42,13 @@ None yet.
 
 ## Governance Facilitator Role (optional)
 
-The governance facilitator role is a non-voting, non-technical advisory position that helps ensure all governance committee meetings are inclusive, and key milestones toward governance are met. The facilitator is a role, meaning it may be occupied by a single individual, or a series of individuals over time. The goal of this position is servant leadership for the project, community, and stakeholders. The committee may choose to make this a permanent role at their discretion. Deliverables may include creation of mailing lists, project tracking boards, governance draft documents, and so forth.
+The governance facilitator role is a non-voting, non-technical advisory position that helps ensure all Governing Board meetings are inclusive, and key milestones toward governance are met. The facilitator is a role, meaning it may be occupied by a single individual, or a series of individuals over time. The goal of this position is servant leadership for the project, community, and stakeholders. The committee may choose to make this a permanent role at their discretion. Deliverables may include creation of mailing lists, project tracking boards, governance draft documents, and so forth.
 
 ## Maximum Representation
 
 No single employer/company may be represented by more than 40% (i.e., 2 seats) of the board at any one time. If the results of an election result in greater than 40% representation, the lowest vote getters from any particular company will be removed until representation on the board is less than one-third.
 
-If percentages shift because of job changes, acquisitions, or other events, sufficient members of the committee must resign until max one-third representation is achieved. If it is impossible to find sufficient members to resign, the entire company’s representation will be removed and new special elections held. In the event of a question of company membership (for example evaluating independence of corporate subsidiaries) a majority of all non-involved Governance Board members will decide.
+If percentages shift because of job changes, acquisitions, or other events, sufficient members of the committee must resign until max one-third representation is achieved. If it is impossible to find sufficient members to resign, the entire company’s representation will be removed and new special elections held. In the event of a question of company membership (for example evaluating independence of corporate subsidiaries) a majority of all non-involved Governing Board members will decide.
 
 ## Committee Responsibilities and Deliverables
 
@@ -71,30 +71,37 @@ The committee is responsible for a series of specific artifacts and activities:
 ## Governance Meetings and Decision-Making Process
 
 Governance decisions, votes and questions should take place on the cdevents-governance@googlegroups.com mailing list.
+The mailing list is publicly readable by everyone.
 
-The governance committee decisions are taken by seeking consensus towards a motion from all its members. If the consensus cannot be reached, the motion may be altered or dropped.
+The Governing Board decisions are taken by seeking consensus towards a motion from all its members. If the consensus cannot be reached, the motion may be altered or dropped.
 
 ## Elections
 
 ### Voter Eligibility
 
-Anyone who has at least 15 [contributions](./process/README.md#contributions) in the last 12 months. The [dashboard on cdevents.devstats.cd.foundation](https://cdevents.devstats.cd.foundation/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=All&var-country_name=All) will show GitHub based contributions; contributions that are not GitHub based must be called out explicitly by the voter to confirm eligibility.
+Anyone who has at least 5 [contributions](/processes.md#contributions) in the last 12 months. The [dashboard on cdevents.devstats.cd.foundation](https://cdevents.devstats.cd.foundation/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=All&var-country_name=All) will show GitHub based contributions; contributions that are not GitHub based must be called out explicitly by the voter to confirm eligibility.
 
 ### Candidate Eligibility
 
-Candidates themselves must be contributors who are eligible to vote, and must be nominated by contributors from at least two companies, which can include their own, and they can self-nominate.
+Candidates themselves must be [contributors](/processes.md#contributor) who are eligible to vote, and must be nominated by contributors from at least two companies, which can include their own, and they can self-nominate.
 
 ### Nominations Process
 
-Nominations should be sent to `cdevents-nominations@googlegroups.com`. The email
-should contain:
+The election officers may decide how to implement the nomination process, as long as the following requirements are fulfilled:
 
-- The nominee’s email address, github handle, company affiliation, and CDEvents
-  project(s) they contribute to
-- For each of two contributors nominating this individual:
-  - The company they work for
-  - Their github handles
-  - The CDEvents project(s) they contribute to
+- Nominations are publicly readable
+- Nominations are persisted over time and can be linked to for future reference
+- Nominations shall contain:
+  - The nominee’s email address, github handle, company affiliation, and CDEvents project(s) they contribute to
+  - For each of two contributors nominating this individual:
+    - The company they work for
+    - Their github handles
+    - The CDEvents project(s) they contribute to
+- Nominee must be nominated by contributors from at least two companies, and they can self-nominate
+- Once all requirements are satisfied, one election officer shall mark the nomination as accepted
+- Nominee may decline a nomination, though it is recommended to reach out to the nominee before posting a public nomination
+
+Two common ways of implementing nominations are either via a dedicated mailing list (e.g. `cdevents-governance@googlegroups.com` or through a dedicated GitHub issue in the community repo). 
 
 Any nominee who accepts the nomination will be on the ballot.
 
@@ -102,74 +109,76 @@ Any nominee who accepts the nomination will be on the ballot.
 
 Elections will be held using time-limited [Condorcet](https://en.wikipedia.org/wiki/Condorcet_method) ranking on [CIVS](https://civs.cs.cornell.edu/) using the [Schulze method](https://en.wikipedia.org/wiki/Schulze_method). The top vote getters will be elected to the open seats. This is the same process used by the Kubernetes project. Voters must opt into the CIVS system at https://civs1.civs.us/cgi-bin/opt_in.pl or they won't receive an invitation to vote.
 
-Details about the schedule and logistics of the election will be announced in a timely manner by the election officers to eligible candidates and voters via the cdevents-dev@googlegroups.com mailing list.
+It may not always be possible for election officers to have access to all voters e-mail addresses. Nomination officials should setup a form or alternate mechanism for eligible voters to share their e-mail address for voting purposes.
+
+Details about the schedule and logistics of the election will be announced in a timely manner by the election officers to eligible candidates and voters via the cdevents-dev@googlegroups.com mailing list, on the #cdevents slack channel and at CDEvents working group meetings.
 
 Example timeline:
 
 1. Before or during nominations, send an email to all eligible voters to notify them that they are eligible (allowing people time to reach out if they believe they are eligible but are not on our list)
 1. Prompt eligible voters to opt into CIVS at https://civs1.civs.us/cgi-bin/opt_in.pl so they will be able to vote
-1. 1 week for nominations (previously, starting on a Thursday until midnight UTC the next Wednesday)
+1. 1 week for nominations (starting on a Thursday until midnight UTC the next Wednesday)
 1. 1 week for the election itself (starting the following Thursday until midnight UTC the next Wednesday)
 
 ### Election Officers
 
-For every election, the governance board wll choose three election officers, by the following criteria, so as to promote healthy rotation and diversity:
+For every election, the Governing Board wll choose two election officers, by the following criteria, so as to promote healthy rotation and diversity:
 
 - election officers must be eligible to vote
-- two election officers should have served before
+- one election officers should have served before
 - one election officer should have never served before
-- each officer should come from a different company to maintain 40% maximal representation
+- each officer should come from a different company to maintain 50% maximal representation
 - election officers should not be currently running in the election
 
-The governing board can decide to make exceptions to the above requirements if needed (for example, if two people cannot be found who have served before and want to be officers).
+The Governing Board can decide to make exceptions to the above requirements if needed (for example, if two people cannot be found who have served before and want to be officers).
 
 ### Vacancies
 
-In the event of a resignation or other loss of an elected governance board member, the candidate with the next most votes from the previous election will be offered the seat. This process will continue until the seat is filled.
+In the event of a resignation or other loss of an elected Governing Board member, the candidate with the next most votes from the previous election will be offered the seat. This process will continue until the seat is filled.
 
 In case this fails to fill the seat, a special election for that position will be held as soon as possible. Eligible voters from the most recent election will vote in the special election (ie: eligibility will not be redetermined at the time of the special election). A board member elected in a special election will 
 serve out the remainder of the term for the person they are replacing, regardless of the length of that remainder.
 
-### Changes to governing board
+### Changes to Governing Board
 
-When someone joins the governing board:
+When someone joins the Governing Board:
 
-- They should be added to [the list of current governing board members](#current-members)
-- They will be added as admins to [the CDEvents GitHub org](https://github.com/cdevents/) via the `governance` GitHub team
+- They should be added to [the list of current Governing Board members](#current-members)
+- They will be added as "owners" to [the CDEvents GitHub org](https://github.com/cdevents/) via the `governance` GitHub team
 - They will be added to these mailing lists as owners:
   - [`cdevents-governance`](https://groups.google.com/g/cdevents-governance)
-  - [`cdevents-nominations`](https://groups.google.com/g/cdevents-nominations)
   - [`cdevents-dev`](https://groups.google.com/g/cdevents-dev)
-  - [`cdevents-users`](https://groups.google.com/g/cdevents-users)
-  - [`cdevents-code-of-conduct`](https://groups.google.com/g/cdevents-code-of-conduct)
 
-When someone leaves the governing board:
+When someone leaves the Governing Board:
 
 - They should be moved from
-  [the list of current governing board members](#current-members) to
+  [the list of current Governing Board members](#current-members) to
   [the list of former members](#former-members-%EF%B8%8F)
 - They will be removed as admins from [the CDEvents GitHub org](https://github.com/cdevents)
 - They will be removed from the `governance` GitHub team
 - They will be removed as owners from these mailing lists:
   - [`cdevents-governance`](https://groups.google.com/g/cdevents-governance)
-  - [`tekton-nominations`](https://groups.google.com/g/cdevents-nominations)
   - [`cdevents-dev`](https://groups.google.com/g/cdevents-dev)
-  - [`cdevents-users`](https://groups.google.com/g/cdevents-users)
-  - [`cdevents-code-of-conduct`](https://groups.google.com/g/cdevents-code-of-conduct)
 
-## Governing board leave policy
+### Exceptions
 
-Any member of the governing board is welcome to take leave from being a governing board member, for any reason (which they are not required to disclose). The actions taken will depend on both of:
+There could be cases where Election Officers may need to follow different processes to ensure the election process can be completed.
 
-1. The length of the leave: whether this is greater or less than approximately (at the discretion of the other governing board members) 1/4 of their total term (since terms are 2 years, this means the criteria is whether or not the leave is greater than 6 months).
+One such case is the number of candidates who run for the Governing Board elections. If the number of candidates is less than the number of seats up for election in Governing Board, Election Officers are authorized to extend the nomination period for one more week. If the number of candidates is still less than the number of seats in Governing Board, Election Officers are authorized to end the nomination and election process so all the candidates assume their seats without election. The remaining seats are left vacant. The new Governing Board is responsible to determine if, when, and how to fill the vacant seats. If the number of candidates is equal to the number of seats in Governing Board, Election Officers are authorized to end the nomination and election process so all the candidates assume their seats without election.
+
+## Governing Board leave policy
+
+Any member of the Governing Board is welcome to take leave from being a Governing Board member, for any reason (which they are not required to disclose). The actions taken will depend on both of:
+
+1. The length of the leave: whether this is greater or less than approximately (at the discretion of the other Governing Board members) 1/4 of their total term (since terms are 2 years, this means the criteria is whether or not the leave is greater than 6 months).
 2. Whether their seat will be up for election during the period of their leave
 
-If the leave is less than or equal to 1/4 of the board member's total term, and their seat will not be up for re-election during that time, the governing board member may select someone to be an acting governing board member for the length of the leave. This person must:
+If the leave is less than or equal to 1/4 of the board member's total term, and their seat will not be up for re-election during that time, the Governing Board member may select someone to be an acting Governing Board member for the length of the leave. This person must:
 
 - Meet [the maximum representation requirement](#maximum-representation)
 - Meet [the candidate eligibility requirements](#candidate-eligibility)
 
-If the length of the leave is greater than 1/4 of the total term, or their seat will be up for election during the leave period, the governing board member will
+If the length of the leave is greater than 1/4 of the total term, or their seat will be up for election during the leave period, the Governing Board member will
 be required to step down from their seat and an election will be held.
 
 ## Code of Conduct
@@ -177,7 +186,7 @@ be required to step down from their seat and an election will be held.
 The code of conduct MUST set expectations for contributors on expected behavior, as well as explaining the consequences of violating the terms of the code.
 The [Contributor Covenant](https://www.contributor-covenant.org) has become the de facto standard for this language.
 
-Members of the governance committee are responsible for handling [CDEvents code of conduct](https://github.com/cdevents/.github/blob/main/docs/CODE_OF_CONDUCT.md)
+Members of the Governing Board are responsible for handling [CDEvents code of conduct](https://github.com/cdevents/.github/blob/main/docs/CODE_OF_CONDUCT.md)
 violations via cdevents-code-of-conduct@googlegroups.com.
 
 ## Outstanding Policies

--- a/governance.md
+++ b/governance.md
@@ -148,6 +148,7 @@ When someone joins the Governing Board:
 - They will be added to these mailing lists as owners:
   - [`cdevents-governance`](https://groups.google.com/g/cdevents-governance)
   - [`cdevents-dev`](https://groups.google.com/g/cdevents-dev)
+  - [`cdevents-code-of-conduct`](https://groups.google.com/g/cdevents-code-of-conduct)
 
 When someone leaves the Governing Board:
 
@@ -159,6 +160,7 @@ When someone leaves the Governing Board:
 - They will be removed as owners from these mailing lists:
   - [`cdevents-governance`](https://groups.google.com/g/cdevents-governance)
   - [`cdevents-dev`](https://groups.google.com/g/cdevents-dev)
+  - [`cdevents-code-of-conduct`](https://groups.google.com/g/cdevents-code-of-conduct)
 
 ### Exceptions
 

--- a/governance.md
+++ b/governance.md
@@ -1,14 +1,32 @@
-# CDEvents Bootstrap Governance
+# CDEvents Governance
 
-The initial bootstrap committee will consist of 5 individuals who are core stakeholders and/or contributors.
+The CDEvents Governance committee is the governing body of the CDEvents open source project. It's an elected group that represents the contributors to the project, and has an oversight on governance and technical matters.
 
-Members are (in alphabetical order):
 
-* Emil Bäckmark, [@e-backmark-ericsson](https://github.com/e-backmark-ericsson), Ericsson
-* Andrea Frittoli, [@afrittoli](https://github.com/afrittoli), IBM
-* Mattias Linnér, [@m-linner-ericsson](https://github.com/m-linner-ericsson), Ericsson
-* Erik Sternerson [@erkist](https://github.com/erkist), doWhile
-* Steve Taylor [@sbtaylor15](https://github.com/sbtaylor15), [DeployHub](https://www.deployhub.com) / [Ortelius OS](https://ortelius.io)
+- [CDEvents Governance Committee](#CDEvents-governance-committee)
+- [Governance Facilitator Role (optional)](#governance-facilitator-role-optional)
+- [Maximum Representation](#maximum-representation)
+- [Committee Responsibilities and Deliverables](#committee-responsibilities-and-deliverables)
+- [Governance Meetings and Decision-Making Process](#governance-meetings-and-decision-making-process)
+- [Elections](#elections)
+- [Permissions and access](#permissions-and-access)
+- [Governing board leave policy](#governing-board-leave-policy)
+
+## CDEvents Governance Committee
+
+The CDEvents governance committee consists of five elected individuals. The five seats are held for two year terms, staggered by one year: every year either two or three of the seats are up for election.
+
+### Current members (Bootstrap)
+
+| Full Name         | Company    | GitHub                                      | Slack                                                         | From | Until    |
+|-------------------|:----------:|---------------------------------------------|---------------------------------------------------------------|------------|----------|
+| Emil Bäckmark     | Ericsson   | [@e-backmark-ericsson](https://github.com/e-backmark-ericsson) | [@Emil Bäckmark](https://cdeliveryfdn.slack.com/team/USR6E330D) | Oct 2021 | 1 year after first election |
+| Andrea Frittoli   | IBM        | [@afrittoli](https://github.com/afrittoli)  | [@Andrea Frittoli](https://cdeliveryfdn.slack.com/team/URNB1NTGR)   | Oct 2021 | 1 year after first |
+| Mattias Linnér    | Ericsson   | [@m-linner-ericsson](https://github.com/m-linner-ericsson) | [@Mattias Linnér](https://cdeliveryfdn.slack.com/team/U01AHR341T8) | Oct 2021 | First Election |
+| Erik Sternerson   | Volvo Cars | [@erkist](https://github.com/erkist) | [@Erik Sternerson](https://cdeliveryfdn.slack.com/team/U01HSV3UVAN) | Oct 2021 | First Election |
+| Steve Taylor      | DeployHub  | [@sbtaylor15](https://github.com/sbtaylor15) | [@Steve Taylor](https://cdeliveryfdn.slack.com/team/U01FMSQSZBN) | Oct 2021 | First Election |
+
+There is no designated facilitator at the moment, the responsibility is distributed across the five members of the committee.
 
 The committee MUST:
 
@@ -18,46 +36,164 @@ The committee MUST:
 * Provide designated alternates in cases where quorum is required but not attainable with the current set of members
 * Communicate with the Continuous Delivery Foundation on a regular cadence
 
-## Committee Deliverables
+#### Former members ❤️
 
-The committee will be responsible for a series of specific artifacts and activities as outlined below.
+None yet.
 
-### Initial Charter
+## Governance Facilitator Role (optional)
 
-This document will define how the committee is to manage the project until it has transitioned to an elected steering body, as well as what governance must be in place.
-The Kubernetes Steering Committee Charter Draft serves as a good example.
+The governance facilitator role is a non-voting, non-technical advisory position that helps ensure all governance committee meetings are inclusive, and key milestones toward governance are met. The facilitator is a role, meaning it may be occupied by a single individual, or a series of individuals over time. The goal of this position is servant leadership for the project, community, and stakeholders. The committee may choose to make this a permanent role at their discretion. Deliverables may include creation of mailing lists, project tracking boards, governance draft documents, and so forth.
 
-A charter should cover all of the following topics:
+## Maximum Representation
 
-* Scope of rights and responsibilities explicitly held by the committee
-* Committee structure that meets the requirements above
-* Election process, including:
-  * special elections in the case someone resigns or is impeached
-  * who is eligible to nominate candidates and how
-  * who is eligible to run as a candidate
-  * Voter registration and requirements
-  * election mechanics such as
-    * committee company representation quotas
-    * Limits on electioneering
-    * Responses to election fraud
-  * How are changes to the charter enacted, and by what process
-  * How are meetings conducted
-    * Recorded or not, and if not, how is the information shared
-    * How is work tracked? Example steering project board
-    * Is there a member note taker, or is there a neutral facilitator role that exists outside of the committee?
-    * Frequency, duration, and required consistency
-  * Committee decision-making process, and specifically those areas of action that require more/less consensus, e.g. modifications the charter
-  * Sub-Steering Committee governance structure (see this example)
+No single employer/company may be represented by more than 40% (i.e., 2 seats) of the board at any one time. If the results of an election result in greater than 40% representation, the lowest vote getters from any particular company will be removed until representation on the board is less than one-third.
 
-## Transition Process
+If percentages shift because of job changes, acquisitions, or other events, sufficient members of the committee must resign until max one-third representation is achieved. If it is impossible to find sufficient members to resign, the entire company’s representation will be removed and new special elections held. In the event of a question of company membership (for example evaluating independence of corporate subsidiaries) a majority of all non-involved Governance Board members will decide.
 
-The transition process MUST:
+## Committee Responsibilities and Deliverables
 
-* Organize, execute, and validate an election for replacing bootstrap members (they may re-run, but would need to be re-elected in order to stay)
-* Define the term lengths for newly-elected individuals, ideally so not all members change out at once
-* Provide documentation for the community and committee members sufficient to smoothly continue the established practices of the committee
+The committee MUST:
 
-## Contribution Process
+- [Represent a cross-section of interests, not just one company](#maximum-representation)
+- Balance technical, architectural, and governance expertise
+- Hold staggered terms, sufficient to ensure an orderly transition of power via elections
+- Provide designated alternates in cases where quorum is required but not attainable with the current set of members
+- Communicate with the Continuous Delivery Foundation on a regular cadence
+
+The committee is responsible for a series of specific artifacts and activities:
+
+- The [Code of Conduct](https://github.com/cdevents/.github/blob/main/docs/CODE_OF_CONDUCT.md) and handling violations
+- The [Project Communication Channels](README.md#how-to-get-involved)
+- The [Contribution Process and Standards](README.md#contributing)
+- The [CDEvents Mission and Vision](https://cdevents.dev)
+- Select [election officers](#election-officers) to run elections
+
+## Governance Meetings and Decision-Making Process
+
+Governance decisions, votes and questions should take place on the cdevents-governance@googlegroups.com mailing list.
+
+The governance committee decisions are taken by seeking consensus towards a motion from all its members. If the consensus cannot be reached, the motion may be altered or dropped.
+
+## Elections
+
+### Voter Eligibility
+
+Anyone who has at least 15 [contributions](./process/README.md#contributions) in the last 12 months. The [dashboard on cdevents.devstats.cd.foundation](https://cdevents.devstats.cd.foundation/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=All&var-country_name=All) will show GitHub based contributions; contributions that are not GitHub based must be called out explicitly by the voter to confirm eligibility.
+
+### Candidate Eligibility
+
+Candidates themselves must be contributors who are eligible to vote, and must be nominated by contributors from at least two companies, which can include their own, and they can self-nominate.
+
+### Nominations Process
+
+Nominations should be sent to `cdevents-nominations@googlegroups.com`. The email
+should contain:
+
+- The nominee’s email address, github handle, company affiliation, and CDEvents
+  project(s) they contribute to
+- For each of two contributors nominating this individual:
+  - The company they work for
+  - Their github handles
+  - The CDEvents project(s) they contribute to
+
+Any nominee who accepts the nomination will be on the ballot.
+
+### Election Process
+
+Elections will be held using time-limited [Condorcet](https://en.wikipedia.org/wiki/Condorcet_method) ranking on [CIVS](https://civs.cs.cornell.edu/) using the [Schulze method](https://en.wikipedia.org/wiki/Schulze_method). The top vote getters will be elected to the open seats. This is the same process used by the Kubernetes project. Voters must opt into the CIVS system at https://civs1.civs.us/cgi-bin/opt_in.pl or they won't receive an invitation to vote.
+
+Details about the schedule and logistics of the election will be announced in a timely manner by the election officers to eligible candidates and voters via the cdevents-dev@googlegroups.com mailing list.
+
+Example timeline:
+
+1. Before or during nominations, send an email to all eligible voters to notify them that they are eligible (allowing people time to reach out if they believe they are eligible but are not on our list)
+1. Prompt eligible voters to opt into CIVS at https://civs1.civs.us/cgi-bin/opt_in.pl so they will be able to vote
+1. 1 week for nominations (previously, starting on a Thursday until midnight UTC the next Wednesday)
+1. 1 week for the election itself (starting the following Thursday until midnight UTC the next Wednesday)
+
+### Election Officers
+
+For every election, the governance board wll choose three election officers, by the following criteria, so as to promote healthy rotation and diversity:
+
+- election officers must be eligible to vote
+- two election officers should have served before
+- one election officer should have never served before
+- each officer should come from a different company to maintain 40% maximal representation
+- election officers should not be currently running in the election
+
+The governing board can decide to make exceptions to the above requirements if needed (for example, if two people cannot be found who have served before and want to be officers).
+
+### Vacancies
+
+In the event of a resignation or other loss of an elected governance board member, the candidate with the next most votes from the previous election will be offered the seat. This process will continue until the seat is filled.
+
+In case this fails to fill the seat, a special election for that position will be held as soon as possible. Eligible voters from the most recent election will vote in the special election (ie: eligibility will not be redetermined at the time of the special election). A board member elected in a special election will 
+serve out the remainder of the term for the person they are replacing, regardless of the length of that remainder.
+
+### Changes to governing board
+
+When someone joins the governing board:
+
+- They should be added to [the list of current governing board members](#current-members)
+- They will be added as admins to [the CDEvents GitHub org](https://github.com/cdevents/) via the `governance` GitHub team
+- They will be added to these mailing lists as owners:
+  - [`cdevents-governance`](https://groups.google.com/g/cdevents-governance)
+  - [`cdevents-nominations`](https://groups.google.com/g/cdevents-nominations)
+  - [`cdevents-dev`](https://groups.google.com/g/cdevents-dev)
+  - [`cdevents-users`](https://groups.google.com/g/cdevents-users)
+  - [`cdevents-code-of-conduct`](https://groups.google.com/g/cdevents-code-of-conduct)
+
+When someone leaves the governing board:
+
+- They should be moved from
+  [the list of current governing board members](#current-members) to
+  [the list of former members](#former-members-%EF%B8%8F)
+- They will be removed as admins from [the CDEvents GitHub org](https://github.com/cdevents)
+- They will be removed from the `governance` GitHub team
+- They will be removed as owners from these mailing lists:
+  - [`cdevents-governance`](https://groups.google.com/g/cdevents-governance)
+  - [`tekton-nominations`](https://groups.google.com/g/cdevents-nominations)
+  - [`cdevents-dev`](https://groups.google.com/g/cdevents-dev)
+  - [`cdevents-users`](https://groups.google.com/g/cdevents-users)
+  - [`cdevents-code-of-conduct`](https://groups.google.com/g/cdevents-code-of-conduct)
+
+## Governing board leave policy
+
+Any member of the governing board is welcome to take leave from being a governing board member, for any reason (which they are not required to disclose). The actions taken will depend on both of:
+
+1. The length of the leave: whether this is greater or less than approximately (at the discretion of the other governing board members) 1/4 of their total term (since terms are 2 years, this means the criteria is whether or not the leave is greater than 6 months).
+2. Whether their seat will be up for election during the period of their leave
+
+If the leave is less than or equal to 1/4 of the board member's total term, and their seat will not be up for re-election during that time, the governing board member may select someone to be an acting governing board member for the length of the leave. This person must:
+
+- Meet [the maximum representation requirement](#maximum-representation)
+- Meet [the candidate eligibility requirements](#candidate-eligibility)
+
+If the length of the leave is greater than 1/4 of the total term, or their seat will be up for election during the leave period, the governing board member will
+be required to step down from their seat and an election will be held.
+
+## Code of Conduct
+
+The code of conduct MUST set expectations for contributors on expected behavior, as well as explaining the consequences of violating the terms of the code.
+The [Contributor Covenant](https://www.contributor-covenant.org) has become the de facto standard for this language.
+
+Members of the governance committee are responsible for handling [CDEvents code of conduct](https://github.com/cdevents/.github/blob/main/docs/CODE_OF_CONDUCT.md)
+violations via cdevents-code-of-conduct@googlegroups.com.
+
+## Outstanding Policies
+
+The following policies have not yet been fully detailed by the governing committee.
+
+### Roadmap and Meetings
+
+Define and maintain the project roadmap:
+* How is work tracked? Example steering project board
+
+How are meetings conducted:
+* Recorded or not, and if not, how is the information shared
+* Frequency, duration, and required consistency
+
+### Contribution Process
 
 The committee MUST define a contribution process that:
 
@@ -77,29 +213,3 @@ The committee MUST define a contribution process that:
 * Identify and document who is responsible for receiving vulnerability reports
 * Document process responsible parties go through to triage and determine veracity of vulnerability
 * Document process for facilitating fix, generating release update, and communicating vulnerability and fix to public
-
-## Code of Conduct
-
-The code of conduct MUST set expectations for contributors on expected behavior, as well as explaining the consequences of violating the terms of the code.
-The [Contributor Covenant](https://www.contributor-covenant.org) has become the de facto standard for this language.
-
-Members of the governance committee will be responsible for handling [CDEvents code of conduct](https://github.com/cdevents/.github/blob/main/docs/CODE_OF_CONDUCT.md)
-violations via cdevents-code-of-conduct@googlegroups.com.
-
-## Project Communication Channels
-
-What are the primary communications channels the project will adopt and manage?
-This can include Slack, mailing lists, an organized Stack Overflow topic, or exist only in GitHub issues and pull requests.
-
-* Mailing list: [groups.google.com/g/cdevents-dev](https://groups.google.com/g/cdevents-dev).
-* Slack: #sig-events [slack channel](https://cdeliveryfdn.slack.com/archives/C0151BTKEJX) on the CDF slack.
-
-Governance decisions, votes and questions should take place on the cdevents-governance@googlegroups.com mailing list.
-
-## Permissions and access
-
-Members of the governing board will be given access to these resources:
-
-* Google Groups Administrators
-* [GitHub Org](https://github.com/cdevents) Administrators
-

--- a/governance.md
+++ b/governance.md
@@ -6,7 +6,7 @@ The CDEvents Governing Board is the governing body of the CDEvents open source p
 - [CDEvents Governing Board](#CDEvents-governing-board)
 - [Governance Facilitator Role (optional)](#governance-facilitator-role-optional)
 - [Maximum Representation](#maximum-representation)
-- [Committee Responsibilities and Deliverables](#committee-responsibilities-and-deliverables)
+- [Board Responsibilities and Deliverables](#board-responsibilities-and-deliverables)
 - [Governance Meetings and Decision-Making Process](#governance-meetings-and-decision-making-process)
 - [Elections](#elections)
 - [Permissions and access](#permissions-and-access)
@@ -26,13 +26,13 @@ The CDEvents Governing Board consists of five elected individuals. The five seat
 | Erik Sternerson   | Volvo Cars | [@erkist](https://github.com/erkist) | [@Erik Sternerson](https://cdeliveryfdn.slack.com/team/U01HSV3UVAN) | Oct 2021 | First Election |
 | Steve Taylor      | DeployHub  | [@sbtaylor15](https://github.com/sbtaylor15) | [@Steve Taylor](https://cdeliveryfdn.slack.com/team/U01FMSQSZBN) | Oct 2021 | First Election |
 
-There is no designated facilitator at the moment, the responsibility is distributed across the five members of the committee.
+There is no designated facilitator at the moment, the responsibility is distributed across the five members of the board.
 
-The committee MUST:
+The board MUST:
 
 * Represent a cross-section of interests, not just one company
 * Balance technical, architectural, and governance expertise since its initial mission is the establishment of structure around contributions, community, and decision-making
-* Hold staggered terms, sufficient to ensure an orderly transition of power via elections as designed and implemented by the committee (see below for specific deliverables)
+* Hold staggered terms, sufficient to ensure an orderly transition of power via elections as designed and implemented by the board (see below for specific deliverables)
 * Provide designated alternates in cases where quorum is required but not attainable with the current set of members
 * Communicate with the Continuous Delivery Foundation on a regular cadence
 
@@ -42,17 +42,17 @@ None yet.
 
 ## Governance Facilitator Role (optional)
 
-The governance facilitator role is a non-voting, non-technical advisory position that helps ensure all Governing Board meetings are inclusive, and key milestones toward governance are met. The facilitator is a role, meaning it may be occupied by a single individual, or a series of individuals over time. The goal of this position is servant leadership for the project, community, and stakeholders. The committee may choose to make this a permanent role at their discretion. Deliverables may include creation of mailing lists, project tracking boards, governance draft documents, and so forth.
+The governance facilitator role is a non-voting, non-technical advisory position that helps ensure all Governing Board meetings are inclusive, and key milestones toward governance are met. The facilitator is a role, meaning it may be occupied by a single individual, or a series of individuals over time. The goal of this position is servant leadership for the project, community, and stakeholders. The board may choose to make this a permanent role at their discretion. Deliverables may include creation of mailing lists, project tracking boards, governance draft documents, and so forth.
 
 ## Maximum Representation
 
 No single employer/company may be represented by more than 40% (i.e., 2 seats) of the board at any one time. If the results of an election result in greater than 40% representation, the lowest vote getters from any particular company will be removed until representation on the board is less than one-third.
 
-If percentages shift because of job changes, acquisitions, or other events, sufficient members of the committee must resign until max one-third representation is achieved. If it is impossible to find sufficient members to resign, the entire company’s representation will be removed and new special elections held. In the event of a question of company membership (for example evaluating independence of corporate subsidiaries) a majority of all non-involved Governing Board members will decide.
+If percentages shift because of job changes, acquisitions, or other events, sufficient members of the board must resign until max one-third representation is achieved. If it is impossible to find sufficient members to resign, the entire company’s representation will be removed and new special elections held. In the event of a question of company membership (for example evaluating independence of corporate subsidiaries) a majority of all non-involved Governing Board members will decide.
 
-## Committee Responsibilities and Deliverables
+## Board Responsibilities and Deliverables
 
-The committee MUST:
+The board MUST:
 
 - [Represent a cross-section of interests, not just one company](#maximum-representation)
 - Balance technical, architectural, and governance expertise
@@ -60,7 +60,7 @@ The committee MUST:
 - Provide designated alternates in cases where quorum is required but not attainable with the current set of members
 - Communicate with the Continuous Delivery Foundation on a regular cadence
 
-The committee is responsible for a series of specific artifacts and activities:
+The board is responsible for a series of specific artifacts and activities:
 
 - The [Code of Conduct](https://github.com/cdevents/.github/blob/main/docs/CODE_OF_CONDUCT.md) and handling violations
 - The [Project Communication Channels](README.md#how-to-get-involved)
@@ -84,6 +84,7 @@ Anyone who has at least 5 [contributions](/processes.md#contributions) in the la
 ### Candidate Eligibility
 
 Candidates themselves must be [contributors](/processes.md#contributor) who are eligible to vote, and must be nominated by contributors from at least two companies, which can include their own, and they can self-nominate.
+Candidates may not serve as [election officers](#election-officers).
 
 ### Nominations Process
 
@@ -122,7 +123,7 @@ Example timeline:
 
 ### Election Officers
 
-For every election, the Governing Board wll choose two election officers, by the following criteria, so as to promote healthy rotation and diversity:
+For every election, the Governing Board will choose two election officers, by the following criteria, so as to promote healthy rotation and diversity:
 
 - election officers must be eligible to vote
 - one election officers should have served before
@@ -193,7 +194,7 @@ violations via cdevents-code-of-conduct@googlegroups.com.
 
 ## Outstanding Policies
 
-The following policies have not yet been fully detailed by the governing committee.
+The following policies have not yet been fully detailed by the governing board.
 
 ### Roadmap and Meetings
 
@@ -206,7 +207,7 @@ How are meetings conducted:
 
 ### Contribution Process
 
-The committee MUST define a contribution process that:
+The board MUST define a contribution process that:
 
 * Explains to potential contributors how/if they can add code to the repository/repositories
 * Documents Workflow and management of pull requests

--- a/governance.md
+++ b/governance.md
@@ -9,8 +9,9 @@ The CDEvents Governing Board is the governing body of the CDEvents open source p
 - [Board Responsibilities and Deliverables](#board-responsibilities-and-deliverables)
 - [Governance Meetings and Decision-Making Process](#governance-meetings-and-decision-making-process)
 - [Elections](#elections)
-- [Permissions and access](#permissions-and-access)
 - [Governing Board leave policy](#governing-board-leave-policy)
+- [Code of Conduct](#code-of-conduct)
+- [Outstanding Policies](#outstanding-policies)
 
 ## CDEvents Governing Board
 
@@ -46,9 +47,9 @@ The governance facilitator role is a non-voting, non-technical advisory position
 
 ## Maximum Representation
 
-No single employer/company may be represented by more than 40% (i.e., 2 seats) of the board at any one time. If the results of an election result in greater than 40% representation, the lowest vote getters from any particular company will be removed until representation on the board is less than one-third.
+No single employer/company may be represented by more than 40% (i.e., 2 seats if all seats are filled) of the board at any one time. If the results of an election result in greater than 40% representation, the lowest vote getters from any particular company will be removed until representation on the board is equal to or less than 40%.
 
-If percentages shift because of job changes, acquisitions, or other events, sufficient members of the board must resign until max one-third representation is achieved. If it is impossible to find sufficient members to resign, the entire company’s representation will be removed and new special elections held. In the event of a question of company membership (for example evaluating independence of corporate subsidiaries) a majority of all non-involved Governing Board members will decide.
+If percentages shift because of job changes, acquisitions, or other events, sufficient members of the board must resign until max 40% representation is achieved. If it is impossible to find sufficient members to resign, the entire company’s representation will be removed and new special elections held. In the event of a question of company membership (for example evaluating independence of corporate subsidiaries) a majority of all non-involved Governing Board members will decide.
 
 ## Board Responsibilities and Deliverables
 
@@ -126,7 +127,7 @@ Example timeline:
 For every election, the Governing Board will choose two election officers, by the following criteria, so as to promote healthy rotation and diversity:
 
 - election officers must be eligible to vote
-- one election officers should have served before
+- one election officer should have served before
 - one election officer should have never served before
 - each officer should come from a different company to maintain 50% maximal representation
 - election officers should not be currently running in the election

--- a/processes.md
+++ b/processes.md
@@ -1,0 +1,201 @@
+# CDEvents project processes
+
+This doc explains general development processes that apply to all projects within the org. Individual projects may have their own processes as well, which you can find documented in their individual CONTRIBUTING.md files.
+
+## Contributions
+
+We try and track community contributions as much as possible to measure the health of the project.
+
+Contributions can include opening PRs, reviewing and commenting on PRs, opening and commenting on issues, writing design docs, commenting on design docs, helping people on slack, and participating in working groups. Where possible, we use dashboards on cdevents.devstats.cd.foundation to track measurable engagement. We try our best to include contributions that are not GitHub, but accuracy varies when we don't have easily available data.
+
+See our [contributor ladder](#contributor-ladder) for more information.
+
+## Contributor Ladder
+
+<!--Big thanks to the folks at https://github.com/cncf/project-template
+for providing the base framework for this section.-->
+
+This contributor ladder outlines the different contributor roles within the project, along with the responsibilities and privileges that come with them. Community members generally start at the first levels of the "ladder" and advance up it as their involvement in the project grows. Our project members are happy to help you advance along the contributor ladder.
+
+Each of the contributor roles below is organized into lists of three types of things. "Responsibilities" are things that contributor is expected to do. "Requirements" are qualifications a person needs to meet to be in that role, and "Privileges" are things contributors on that level are entitled to.
+
+### Community Participant
+
+Description: A Community Participant engages with the project and its community, contributing their time, thoughts, etc. Community participants are usually users who have stopped being anonymous and started being active in project discussions.
+
+* Responsibilities:
+  * Must follow the [CDEvents Code of Conduct](https://github.com/cdevents/.github/blob/main/docs/CODE_OF_CONDUCT.md)
+* How users can get involved with the community:
+  * Participating in community discussions
+    ([GitHub, Slack, mailing list, etc](/README.md#how-to-get-involved))
+  * Helping other users
+  * Submitting bug reports
+  * Commenting on issues
+  * Trying out new releases
+  * Attending community events
+
+### Contributor
+
+Description: A Contributor makes direct contributions to the project and adds value to it. [Contributions need not be code](#contributions). People at the Contributor level may be new contributors, and they can contribute occasionally.
+
+Contributors may be eligible to vote and run in elections. See [Elections](/governance.md#elections) for more details.
+
+A Contributor must meet the responsibilities of a [Community Participant](#community-participant), plus:
+
+* Responsibilities include:
+  * Follow the project contributing guide (see `CONTRIBUTING.md` in the
+    corresponding repo)
+* Requirements (one or several of the below):
+  * Report and sometimes resolve issues
+  * Occasionally submit PRs
+  * Contribute to the documentation
+  * Participate in [meetings](/README.md#how-to-get-involved)
+  * Answer questions from other community members
+  * Submit feedback on issues and PRs
+  * Test, review, and verify releases and patches
+* Privileges:
+  * Invitations to contributor events
+  * Eligible to become an [Organization Member](#organization-member)
+
+### Organization Member
+
+Description: An Organization Member is an established contributor who regularly participates in the project. Organization Members have privileges in project repositories.
+
+An Organization Member must meet the responsibilities and has the requirements of a [Contributor](#contributor), plus:
+
+* Responsibilities include:
+  * Continues to contribute regularly, as demonstrated by having at least 15
+    contributions a year, as demonstrated by
+    [the CDEvents devstats dashboard](https://cdevents.devstats.cd.foundation/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=All&var-country_name=All).
+* Requirements:
+  * Subscribed to the [cdevents-dev mailing list](/README.md#how-to-get-involved).
+  * Actively contributing to 1 or more subprojects.
+  * Must have successful contributions to the project, including at least one of
+    the following:
+    * Authored or Reviewed 5 PRs,
+    * Or be endorsed by at least 2 existing Org Members:
+      * Endorsers should have close interactions with the prospective member - e.g. code/design/proposal review, coordinating on issues, etc.
+      * Endorsers must be reviewers or approvers in at least one OWNERS file within one of the Tekton sub-projects.
+      * Endorsers must be from multiple member organizations to demonstrate integration across community.
+  * Must have 2FA enabled on their GitHub account
+* Privileges:
+  * [GitHub default organization member privileges](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#permissions-for-organization-roles)
+  * Can recommend other contributors to become Org Members
+
+The process for a Contributor to become an Organization Member is as follows:
+
+1. Request an organization owner to be added to the GitHub organization
+
+## Reviewer
+
+Description: A Reviewer has responsibility for specific code, documentation, test, or other project areas. They are collectively responsible, with other Reviewers, for reviewing all changes to those areas and indicating whether those changes are ready to merge. They have a track record of contribution and review in the project.
+
+Reviewers are responsible for a "specific area." This can be a specific code directory, driver, chapter of the docs, test job, event, or other clearly-defined project component that is smaller than an entire repository or subproject. Most often it is one or a set of directories in one or more Git repositories. The "specific area" below refers to this area of responsibility.
+
+Reviewers have all the rights and responsibilities of an [Organization Member](#organization-member), plus:
+
+* Responsibilities include:
+  * Proactively help triage and respond to incoming issues (GitHub, Slack, mailing list)
+  * Following the [reviewing guide](../standards.md)
+  * Reviewing most Pull Requests against their specific areas of responsibility
+  * Reviewing at least 5 PRs per year
+  * Helping other contributors become reviewers
+* Requirements:
+  * Experience as a [Contributor](#contributor) for at least 2 months or 50% of the project lifetime, whichever is shorter
+  * Has authored or reviewed at least 8 Pull Requests
+    * including being the primary reviewer for at least 3 of the above
+  * Has analyzed and resolved test failures in their specific area
+  * Has demonstrated an in-depth knowledge of the specific area
+  * Commits to being responsible for that specific area
+  * Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
+* Additional privileges:
+  * Review pull requests, triage issues
+  * All privileges granted by the [GitHub triage role](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role)
+  * Can recommend and review other contributors to become Reviewers
+
+To facilitate productivity, small repositories, repositories that do not contain production code or that have a low traffic of PRs may decide to use simpler requirements. Each of these projects may define their own requirements. Each of these projects may define their own requirements, in a local `processes.md` file.
+
+* Be an OWNER on any other repository in the Tekton project, and ask an existing OWNER to add you.
+* Or, Be nominated by another OWNER (with no objections from other OWNERs)
+
+The process of becoming a Reviewer is:
+
+1. The contributor is nominated by opening a PR against the appropriate project, adding the contributor to `REVIEWERS.md`
+2. At least two Reviewers/[Maintainers](#maintainer) of the team that owns that repository approve the nomination PR.
+3. Update the GitHub project reviewer team
+
+* Each project has a `<repo>.-reviewers` team defined, where `<repo>` is the name of the GitHub repository.
+
+## Maintainer
+
+Description: Maintainers are very established contributors who are responsible for entire projects. As such, they have the ability to approve PRs against any area of a project, and are expected to participate in making decisions about the strategy and priorities of the project.
+
+A Maintainer must meet the responsibilities and requirements of a [Reviewer](#Reviewer), plus:
+
+- Responsibilities include:
+  - Reviewing PRs that involve multiple parts of the project
+  - Mentoring new [Contributors](#contributor) and [Reviewers](#Reviewer)
+  - Writing PRs that involve many parts of the project (e.g. refactoring)
+  - Participating in Tekton maintainer activities (build captain, WG lead)
+  - Determining strategy and policy for the project
+  - Participating in, and leading, community meetings
+  - Mentoring other contributors
+- Requirements
+  - Have been actively participating in reviews for at least 3 months or 50% of the project lifetime, whichever is shorter
+  - Has authored or reviewed at least 10 PRs to the codebase.
+    - Have been the primary reviewer for at least 5 substantial PRs to the codebase.
+  - Demonstrates a broad knowledge of the project across multiple areas
+  - Is able to exercise judgement for the good of the project, independent of their employer, friends, or team
+  - Be nominated by another Maintainer (with no objections from other Maintainers)
+- Additional privileges:
+  - Approve PRs to any area of the project
+  - Granted access to shared Tekton CI/CD infrastructure
+  - Represent the project in public as a Maintainer
+  - Have a vote in Maintainer decision-making meetings
+
+To facilitate productivity, small repositories, repositories that do not contain production code or that have a low traffic of PRs may decide to use simpler requirements. Each of these projects may define their own requirements, in a local `processes.md` file.
+
+Process of becoming an Maintainer:
+
+1. Any current Maintainer may nominate a current [Reviewer](#Reviewer) to become a new Maintainer, by opening a PR against the appropriate project, adding the contributor to `MAINTAINERS.md`
+2. The nominee will add a comment to the PR testifying that they agree to all requirements of becoming a Maintainer.
+3. A majority of the current Maintainers must then approve.
+4. Add the new maintainer to the corresponding GitHub team
+
+- Each project has a `<repo>-maintainers` team, where `<repo>` is the name of the GitHub repository.
+
+## Governance Committee Member
+
+Description: The CDEvents Governance committee is the governing body of the CDEvents open source project. It's an elected group that represents the contributors to the project, and has an oversight on governance and technical matters.
+
+See [governance.md](/governance.md) for requirements, responsibilities, and election process.
+
+- Additional privileges:
+  - Maintainer privileges on all CDEvents projects
+  - Organization admin access.
+
+Members of the governance committee belong to the the `governance` GitHub team.
+
+## Inactivity
+
+It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
+
+- Inactivity is measured by:
+  - Failing to meet role requirements.
+  - Periods of no [contributions](./README.md#contributions) for longer than 4 months
+  - Periods of no communication for longer than 2 months
+- Consequences of being inactive include:
+  - Involuntary removal or demotion
+  - Being asked to move to Emeritus status
+
+### Involuntary Removal or Demotion
+
+Involuntary removal/demotion of a contributor happens when responsibilities and requirements aren't being met. This may include repeated patterns of inactivity, extended period of inactivity, a period of failing to meet the requirements of your role, and/or a violation of the Code of Conduct. This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
+
+Involuntary removal or demotion is handled through a vote by a majority of the [CDEvents Governing Board](/governance.md).
+
+### Stepping Down/Emeritus Process
+
+If and when contributors' commitment levels change, contributors can consider stepping down (moving down the contributor ladder) vs moving to emeritus status (completely stepping away from the project).
+
+Contact the Maintainers about changing to Emeritus status, or reducing your contributor level.

--- a/processes.md
+++ b/processes.md
@@ -6,7 +6,7 @@ This doc explains general development processes that apply to all projects withi
 
 We try and track community contributions as much as possible to measure the health of the project.
 
-Contributions can include opening PRs, reviewing and commenting on PRs, opening and commenting on issues, writing design docs, commenting on design docs, helping people on slack, and participating in working groups. Where possible, we use dashboards on cdevents.devstats.cd.foundation to track measurable engagement. We try our best to include contributions that are not GitHub, but accuracy varies when we don't have easily available data.
+Contributions can include opening PRs, reviewing and commenting on PRs, opening and commenting on issues, writing design docs, commenting on design docs, helping people on slack, and participating in working groups. Where possible, we use dashboards on [cdevents.devstats.cd.foundation](https://cdevents.devstats.cd.foundation) to track measurable engagement. We try our best to include contributions that are not GitHub, but accuracy varies when we don't have easily available data.
 
 See our [contributor ladder](#contributor-ladder) for more information.
 
@@ -75,7 +75,7 @@ An Organization Member must meet the responsibilities and has the requirements o
     * Authored or Reviewed 5 PRs,
     * Or be endorsed by at least 2 existing Org Members:
       * Endorsers should have close interactions with the prospective member - e.g. code/design/proposal review, coordinating on issues, etc.
-      * Endorsers must be maintainers of at lease one of the CDEvents sub-projects.
+      * Endorsers must be maintainers of at least one of the CDEvents sub-projects.
       * Endorsers must be from multiple member organizations to demonstrate integration across community.
   * Must have 2FA enabled on their GitHub account
 * Privileges:
@@ -95,16 +95,16 @@ A Maintainer must meet the responsibilities and requirements of an [organization
 - Responsibilities include:
   - Proactively help triage and respond to incoming issues (GitHub, Slack, mailing list)
   - Reviewing PRs that involve multiple parts of the project
-  - Mentoring new [Contributors](#contributor) and [Reviewers](#Reviewer)
+  - Mentoring new [Contributors](#contributor)
   - Writing PRs that involve many parts of the project (e.g. refactoring)
   - Participating in CDEvents maintainer activities (Facilitate working group, triage issues)
   - Determining strategy and policy for the project
   - Participating in, and leading, community meetings
   - Mentoring other contributors
 - Requirements
-  - Have been actively participating in reviews for at least 3 months or 50% of the project lifetime, whichever is shorter
+  - Has been actively participating in reviews for at least 3 months or 50% of the project lifetime, whichever is shorter
   - Has authored or reviewed at least 10 PRs to the codebase.
-    - Have been the primary reviewer for at least 5 substantial PRs to the codebase.
+    - Has been the primary reviewer for at least 5 substantial PRs to the codebase.
   - Demonstrates a broad knowledge of the project across multiple areas
   - Is able to exercise judgement for the good of the project, independent of their employer, friends, or team
   - Be nominated by another Maintainer (with no objections from other Maintainers)
@@ -160,7 +160,7 @@ Involuntary removal or demotion is handled through a vote by a majority of the [
 
 If and when contributors' commitment levels change, contributors (at any level) can consider stepping down (moving down the contributor ladder) vs moving to emeritus status (completely stepping away from the project).
 
-[Community participants](#community-participant), [contributors](#contributor) and [organization members](#organization-member) may change their contribution level autonomously.
+[Community participants](#community-participant), [contributors](#contributor) and [organization members](#organization-member) may reduce their contributor level autonomously.
 
 [Maintainers](#maintainer) shall contact the other maintainers about changing to Emeritus status, or reducing their contributor level.
 CDEvents projects may opt for tracking emeritus maintainers in their `CODEOWNERS` file.

--- a/processes.md
+++ b/processes.md
@@ -75,7 +75,7 @@ An Organization Member must meet the responsibilities and has the requirements o
     * Authored or Reviewed 5 PRs,
     * Or be endorsed by at least 2 existing Org Members:
       * Endorsers should have close interactions with the prospective member - e.g. code/design/proposal review, coordinating on issues, etc.
-      * Endorsers must be reviewers or approvers in at least one OWNERS file within one of the CDEvents sub-projects.
+      * Endorsers must be maintainers of at lease one of the CDEvents sub-projects.
       * Endorsers must be from multiple member organizations to demonstrate integration across community.
   * Must have 2FA enabled on their GitHub account
 * Privileges:
@@ -86,53 +86,14 @@ The process for a Contributor to become an Organization Member is as follows:
 
 1. Request an organization owner to be added to the GitHub organization
 
-## Reviewer
-
-Description: A Reviewer has responsibility for specific code, documentation, test, or other project areas. They are collectively responsible, with other Reviewers, for reviewing all changes to those areas and indicating whether those changes are ready to merge. They have a track record of contribution and review in the project.
-
-Reviewers are responsible for a "specific area." This can be a specific code directory, driver, chapter of the docs, test job, event, or other clearly-defined project component that is smaller than an entire repository or subproject. Most often it is one or a set of directories in one or more Git repositories. The "specific area" below refers to this area of responsibility.
-
-Reviewers have all the rights and responsibilities of an [Organization Member](#organization-member), plus:
-
-* Responsibilities include:
-  * Proactively help triage and respond to incoming issues (GitHub, Slack, mailing list)
-  * Following the [reviewing guide](../standards.md)
-  * Reviewing most Pull Requests against their specific areas of responsibility
-  * Reviewing at least 5 PRs per year
-  * Helping other contributors become reviewers
-* Requirements:
-  * Experience as a [Contributor](#contributor) for at least 2 months or 50% of the project lifetime, whichever is shorter
-  * Has authored or reviewed at least 8 Pull Requests
-    * including being the primary reviewer for at least 3 of the above
-  * Has analyzed and resolved test failures in their specific area
-  * Has demonstrated an in-depth knowledge of the specific area
-  * Commits to being responsible for that specific area
-  * Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
-* Additional privileges:
-  * Review pull requests, triage issues
-  * All privileges granted by the [GitHub triage role](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role)
-  * Can recommend and review other contributors to become Reviewers
-
-To facilitate productivity, small repositories, repositories that do not contain production code or that have a low traffic of PRs may decide to use simpler requirements. Each of these projects may define their own requirements. Each of these projects may define their own requirements, in a local `processes.md` file.
-
-* Be an OWNER on any other repository in the CDEvents project, and ask an existing OWNER to add you.
-* Or, Be nominated by another OWNER (with no objections from other OWNERs)
-
-The process of becoming a Reviewer is:
-
-1. The contributor is nominated by opening a PR against the appropriate project, adding the contributor to `REVIEWERS.md`
-2. At least two Reviewers/[Maintainers](#maintainer) of the team that owns that repository approve the nomination PR.
-3. Update the GitHub project reviewer team
-
-* Each project has a `<repo>.-reviewers` team defined, where `<repo>` is the name of the GitHub repository.
-
 ## Maintainer
 
 Description: Maintainers are very established contributors who are responsible for entire projects. As such, they have the ability to approve PRs against any area of a project, and are expected to participate in making decisions about the strategy and priorities of the project.
 
-A Maintainer must meet the responsibilities and requirements of a [Reviewer](#Reviewer), plus:
+A Maintainer must meet the responsibilities and requirements of an [organization member](#organization-member), plus:
 
 - Responsibilities include:
+  - Proactively help triage and respond to incoming issues (GitHub, Slack, mailing list)
   - Reviewing PRs that involve multiple parts of the project
   - Mentoring new [Contributors](#contributor) and [Reviewers](#Reviewer)
   - Writing PRs that involve many parts of the project (e.g. refactoring)
@@ -157,14 +118,15 @@ To facilitate productivity, small repositories, repositories that do not contain
 
 Process of becoming an Maintainer:
 
-1. Any current Maintainer may nominate a current [Reviewer](#Reviewer) to become a new Maintainer, by opening a PR against the appropriate project, adding the contributor to `CODEOWNWERS`
-2. The nominee will add a comment to the PR testifying that they agree to all requirements of becoming a Maintainer.
+1. Any current Maintainer may nominate a current [organization member](#organization-member) to become a new Maintainer, by opening an issue against the appropriate project.
+2. The nominee will add a comment to the issue testifying that they agree to all requirements of becoming a Maintainer.
 3. A majority of the current Maintainers must then approve.
 4. Add the new maintainer to the corresponding GitHub team
+5. (Optional) Update `CODEOWNWERS` with specific areas of expertise for the new maintainer. Add the new maintainer to the list of maintainers kept in a comment in `CODEOWNWERS`.
 
 - Each project has a `<repo>-maintainers` team, where `<repo>` is the name of the GitHub repository.
 
-## Governing Board Member  Member
+## Governing Board Member
 
 Description: The CDEvents Governing board is the governing body of the CDEvents open source project. It's an elected group that represents the contributors to the project, and has an oversight on governance and technical matters.
 
@@ -178,7 +140,7 @@ Members of the governing board belong to the the `governance` GitHub team.
 
 ## Inactivity
 
-It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
+It is important for contributors, especially maintainers and governing board members, to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
 
 - Inactivity is measured by:
   - Failing to meet role requirements.
@@ -190,13 +152,18 @@ It is important for contributors to be and stay active to set an example and sho
 
 ### Involuntary Removal or Demotion
 
-Involuntary removal/demotion of a contributor happens when responsibilities and requirements aren't being met. This may include repeated patterns of inactivity, extended period of inactivity, a period of failing to meet the requirements of your role, and/or a violation of the Code of Conduct. This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
+Involuntary removal/demotion of a contributor (at any level) happens when responsibilities and requirements aren't being met. This may include repeated patterns of inactivity, extended period of inactivity, a period of failing to meet the requirements of your role, and/or a violation of the Code of Conduct. This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
 
 Involuntary removal or demotion is handled through a vote by a majority of the [CDEvents Governing Board](/governance.md).
 
 ### Stepping Down/Emeritus Process
 
-If and when contributors' commitment levels change, contributors can consider stepping down (moving down the contributor ladder) vs moving to emeritus status (completely stepping away from the project).
+If and when contributors' commitment levels change, contributors (at any level) can consider stepping down (moving down the contributor ladder) vs moving to emeritus status (completely stepping away from the project).
 
-Contact the Maintainers about changing to Emeritus status, or reducing your contributor level.
+[Community participants](#community-participant), [contributors](#contributor) and [organization members](#organization-member) may change their contribution level autonomously.
+
+[Maintainers](#maintainer) shall contact the other maintainers about changing to Emeritus status, or reducing their contributor level.
+CDEvents projects may opt for tracking emeritus maintainers in their `CODEOWNERS` file.
+
+[Governing Board members](#governing-board-member) shall contact the other Governing Board members about changing to Emeritus status, or reducing their contributor level.
 Emeritus Governing Board members are tracked in the [governance](/governance.md#former-members-❤️) documentation.

--- a/processes.md
+++ b/processes.md
@@ -75,7 +75,7 @@ An Organization Member must meet the responsibilities and has the requirements o
     * Authored or Reviewed 5 PRs,
     * Or be endorsed by at least 2 existing Org Members:
       * Endorsers should have close interactions with the prospective member - e.g. code/design/proposal review, coordinating on issues, etc.
-      * Endorsers must be reviewers or approvers in at least one OWNERS file within one of the Tekton sub-projects.
+      * Endorsers must be reviewers or approvers in at least one OWNERS file within one of the CDEvents sub-projects.
       * Endorsers must be from multiple member organizations to demonstrate integration across community.
   * Must have 2FA enabled on their GitHub account
 * Privileges:
@@ -115,7 +115,7 @@ Reviewers have all the rights and responsibilities of an [Organization Member](#
 
 To facilitate productivity, small repositories, repositories that do not contain production code or that have a low traffic of PRs may decide to use simpler requirements. Each of these projects may define their own requirements. Each of these projects may define their own requirements, in a local `processes.md` file.
 
-* Be an OWNER on any other repository in the Tekton project, and ask an existing OWNER to add you.
+* Be an OWNER on any other repository in the CDEvents project, and ask an existing OWNER to add you.
 * Or, Be nominated by another OWNER (with no objections from other OWNERs)
 
 The process of becoming a Reviewer is:
@@ -136,7 +136,7 @@ A Maintainer must meet the responsibilities and requirements of a [Reviewer](#Re
   - Reviewing PRs that involve multiple parts of the project
   - Mentoring new [Contributors](#contributor) and [Reviewers](#Reviewer)
   - Writing PRs that involve many parts of the project (e.g. refactoring)
-  - Participating in Tekton maintainer activities (build captain, WG lead)
+  - Participating in CDEvents maintainer activities (Facilitate working group, triage issues)
   - Determining strategy and policy for the project
   - Participating in, and leading, community meetings
   - Mentoring other contributors
@@ -149,7 +149,7 @@ A Maintainer must meet the responsibilities and requirements of a [Reviewer](#Re
   - Be nominated by another Maintainer (with no objections from other Maintainers)
 - Additional privileges:
   - Approve PRs to any area of the project
-  - Granted access to shared Tekton CI/CD infrastructure
+  - Granted access to shared CDEvents CI/CD infrastructure
   - Represent the project in public as a Maintainer
   - Have a vote in Maintainer decision-making meetings
 
@@ -199,3 +199,4 @@ Involuntary removal or demotion is handled through a vote by a majority of the [
 If and when contributors' commitment levels change, contributors can consider stepping down (moving down the contributor ladder) vs moving to emeritus status (completely stepping away from the project).
 
 Contact the Maintainers about changing to Emeritus status, or reducing your contributor level.
+Emeritus Governing Board members are tracked in the [governance](/governance.md#former-members-❤️) documentation.

--- a/processes.md
+++ b/processes.md
@@ -157,16 +157,16 @@ To facilitate productivity, small repositories, repositories that do not contain
 
 Process of becoming an Maintainer:
 
-1. Any current Maintainer may nominate a current [Reviewer](#Reviewer) to become a new Maintainer, by opening a PR against the appropriate project, adding the contributor to `MAINTAINERS.md`
+1. Any current Maintainer may nominate a current [Reviewer](#Reviewer) to become a new Maintainer, by opening a PR against the appropriate project, adding the contributor to `CODEOWNWERS`
 2. The nominee will add a comment to the PR testifying that they agree to all requirements of becoming a Maintainer.
 3. A majority of the current Maintainers must then approve.
 4. Add the new maintainer to the corresponding GitHub team
 
 - Each project has a `<repo>-maintainers` team, where `<repo>` is the name of the GitHub repository.
 
-## Governance Committee Member
+## Governing Board Member  Member
 
-Description: The CDEvents Governance committee is the governing body of the CDEvents open source project. It's an elected group that represents the contributors to the project, and has an oversight on governance and technical matters.
+Description: The CDEvents Governing board is the governing body of the CDEvents open source project. It's an elected group that represents the contributors to the project, and has an oversight on governance and technical matters.
 
 See [governance.md](/governance.md) for requirements, responsibilities, and election process.
 
@@ -174,7 +174,7 @@ See [governance.md](/governance.md) for requirements, responsibilities, and elec
   - Maintainer privileges on all CDEvents projects
   - Organization admin access.
 
-Members of the governance committee belong to the the `governance` GitHub team.
+Members of the governing board belong to the the `governance` GitHub team.
 
 ## Inactivity
 


### PR DESCRIPTION
Add a number of policies and documents about CDEvents governance and processes. A lot of content is inspired by the Tekton community governance documents and adapted for CDEvents.

Key new things added:
- governing boards elections (eligibility, etc)
- contributor roles and ladder (eligibility, etc)

Some new mailing lists will have to be created.

The current bootstrap committee includes 5 individuals. My proposal is to keep a team of five. For continuity, I propose that
- We held elections for three of the seats, to ensure continuity in the project governance.
- Emil and Andrea have been acting as project governance since the beginning, so their seats that be maintained until after 1 year after the election
- Nattias, Erik and Steve seats are up for election